### PR TITLE
Add product lookup modal and API

### DIFF
--- a/src/app/api/producto/route.ts
+++ b/src/app/api/producto/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const code = searchParams.get("code");
+  if (!code) {
+    return new Response(JSON.stringify({ error: "Código no provisto" }), { status: 400 });
+  }
+
+  const query = `${code} site:amazon.com OR site:mercadolibre.com.ar OR site:openfoodfacts.org`;
+  try {
+    const serpRes = await fetch(
+      `https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(query)}&api_key=${process.env.SERP_API_KEY}`
+    );
+    const serpData = await serpRes.json();
+
+    const productTitle = serpData?.organic_results?.[0]?.title || "Producto desconocido";
+    const snippet = serpData?.organic_results?.[0]?.snippet || "";
+    let image = serpData?.images_results?.[0]?.thumbnail;
+    if (!image && serpData?.inline_images?.[0]?.thumbnail) {
+      image = serpData.inline_images[0].thumbnail;
+    }
+
+    const prompt = `
+Generá una descripción breve y clara del siguiente producto para una tienda online. Mantené un estilo neutral y profesional.
+La descripción debe tener:
+- Un párrafo de 3 a 4 líneas que describa el producto
+- Debajo, bullet points con las características clave ("key features") del producto
+
+Producto: "${productTitle}"
+Descripción original: "${snippet}"
+
+No repitas el nombre del producto en la descripción.
+`;
+
+    const openaiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.7,
+      }),
+    });
+
+    const openaiJson = await openaiRes.json();
+    const descripcion = openaiJson.choices?.[0]?.message?.content?.trim() || "";
+
+    return Response.json({
+      nombre: productTitle,
+      imagen: image || "",
+      descripcion,
+    });
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ error: "Error al buscar producto" }), { status: 500 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "UPC API Lookup",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,17 @@
+import { ButtonHTMLAttributes } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "secondary" | "destructive";
+}
+
+export function Button({ variant = "default", className = "", ...props }: ButtonProps) {
+  const base = "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none";
+  const variants: Record<string, string> = {
+    default: "bg-black text-white hover:bg-gray-800 focus:ring-black",
+    secondary: "bg-gray-100 text-black hover:bg-gray-200 focus:ring-gray-300",
+    destructive: "bg-red-600 text-white hover:bg-red-700 focus:ring-red-600",
+  };
+  return (
+    <button className={`${base} ${variants[variant]} ${className}`} {...props} />
+  );
+}

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,32 @@
+import { ReactNode, useState, useRef, useEffect } from "react";
+
+interface DropdownMenuProps {
+  trigger: ReactNode;
+  children: ReactNode;
+}
+
+export function DropdownMenu({ trigger, children }: DropdownMenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <div onClick={() => setOpen((o) => !o)} className="cursor-pointer">
+        {trigger}
+      </div>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 bg-white border rounded-md shadow-md z-10">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,10 @@
+import { InputHTMLAttributes } from "react";
+
+export function Input({ className = "", ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={`border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black ${className}`}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,5 @@
+import { LabelHTMLAttributes } from "react";
+
+export function Label({ className = "", ...props }: LabelHTMLAttributes<HTMLLabelElement>) {
+  return <label className={`text-sm font-medium ${className}`} {...props} />;
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function Modal({ open, onClose, children }: ModalProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-md p-6 w-full max-w-lg relative">
+        <button className="absolute top-2 right-2" onClick={onClose}>✕</button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,8 @@
+export function Spinner() {
+  return (
+    <svg className="animate-spin h-5 w-5 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+  );
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,10 @@
+import { TextareaHTMLAttributes } from "react";
+
+export function Textarea({ className = "", ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={`border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black ${className}`}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/api/producto` route that queries SerpAPI and OpenAI
- simplify layout font loading
- build UI primitives (Button, Input, Modal, etc.) in `src/components/ui`
- create new product search page with modal form and table

## Testing
- `npm run lint`
- `npm run build` *(fails to fetch Google fonts but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_6874146b47a8832ba8d6fdd26e0093fe